### PR TITLE
docs: add note for socket.io / websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [Loco](https://loco.rs) is a web and API framework running on Rust.
 
-This is the **SaaS starter** which includes a `User` model and authentication based on JWT.
-It also include configuration sections that help you pick either a frontend or a server-side template set up for your fullstack server.
+THis is a chatroom example to show how websockets are implemented.
+
+Note that this is not a regular WebSocket application, you'll need to use socket.io on the client side to get this to work. Socket.io supports long-polling fallbacks, rooms, and other things that raw WebSockets don't support. See [Axum websocket example](https://github.com/tokio-rs/axum/blob/main/examples/websockets/src/main.rs) for inspiration for building a pure WebSocket application.
 
 
 ## Quick Start


### PR DESCRIPTION
See https://github.com/loco-rs/chat-rooms/issues/8#issuecomment-2564688799 for a discussion on this.

Note I got this working but in private code, also using API key authentication via the [SecWebSocketProtocol "hack"](https://stackoverflow.com/questions/44743482/using-sec-websocket-protocol-for-authentication), so that I get a regular user account back. If anyone is interested in the code for this at some point, let me know and if I have some time I can maybe contribute a working example.